### PR TITLE
Add fatal

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The API is fairly confined and straightforward, so it is worth looking into the 
 * context-specific logger instances, e.g. those for a package, a struct or a module, are retrieved from the factory using `slf.WithContext(contextDef)`. The interface prescribes at least one structured field, `context`;
 * these can then be used with fields to define the structure of log entries or even without any further fields, just like a plain vanilla logger. Arbitrary fields are accepted via `WithField("key", value)` or `WithFields(slf.Fields{"key": value})` and the predefined ones via `WithError(err)` or `WithCaller(slf.CallerShort)`;
 * leveled log entries can be generated with or without a formatter, `logger.Debugf("%v", "message")` and `logger.Info("message")`;
-* the interface defines 5 serializable log levels `DEBUG`, `INFO`, `WARN`, `ERROR`, `PANIC` (`TRACE` and `FATAL` are explicitly excluded and the discussion about their necessity is rather a philosophical one);
+* the interface defines 5 serializable log levels `DEBUG`, `INFO`, `WARN`, `ERROR`, `PANIC`, `FATAL` (`TRACE` is explicitly excluded);
 * finally, each log entry can be followed by a `Trace` method, which is supposed to log execution time counting from the last log entry by the same logger using the same log level as the last log entry. Using it with `defer` provides a clean mechanism to trace the execution times of methods in one line.
 
 The interface defines no structure of the actual log entry, nor the mechanism of how the log levels are set to the contexts (if at all), nor log entry handler interface, nor the actual log entry handlers. All these entities are what libraries using the logger do not care about and are only of concern for the application putting the libraries together. Therefore, all of these are deferred to the actual implementation used in the application (and are for example defined in the reference [slog] implementation).
@@ -30,7 +30,7 @@ The interface defines no structure of the actual log entry, nor the mechanism of
 
 ### Using within a library
 
-As mentioned above, there is no need to bind any implementation of SLF into a library. The `slf` module provides a `Noop` implementation by default, that is the one with No-Operation, which will make sure your library does not panic on missing logging implementation. The factory methods and all the logging routines will work as is, yet no output will be generated. One exception is the `Panic` command, which will panic even though no log output will be generated.
+As mentioned above, there is no need to bind any implementation of SLF into a library. The `slf` module provides a `Noop` implementation by default, that is the one with No-Operation, which will make sure your library does not panic on missing logging implementation. The factory methods and all the logging routines will work as is, yet no output will be generated. Two exceptions are the `Panic` command, which will panic even though no log output will be generated, and `Fatal`, which will call `os.Exit(1)` even though no log output will be generated.
 
 One should be careful not to initialise any context logger, that is the one obtained with `slf.WithContext`, in the `init` or into a package-level variable directly, as this will return an instance of the `Noop` implementation before the factory could be reset to use an actual logging implementation in the main application. However, the following three approaches are all valid:
 

--- a/level.go
+++ b/level.go
@@ -18,6 +18,7 @@ const (
 	LevelWarn
 	LevelError
 	LevelPanic
+	LevelFatal
 )
 
 func (l Level) String() string {
@@ -40,6 +41,8 @@ func (l Level) string() (string, error) {
 		return "ERROR", nil
 	case LevelPanic:
 		return "PANIC", nil
+	case LevelFatal:
+		return "FATAL", nil
 	default:
 		return "", fmt.Errorf("slf: unknown level %d", int(l))
 	}
@@ -78,6 +81,10 @@ func (l *Level) UnmarshalJSON(data []byte) error {
 		fallthrough
 	case "panic":
 		*l = LevelPanic
+	case `"fatal"`:
+		fallthrough
+	case "fatal":
+		*l = LevelFatal
 	default:
 		return fmt.Errorf("slf: unknown level %v", s)
 	}

--- a/level_test.go
+++ b/level_test.go
@@ -37,6 +37,10 @@ func TestLevel_marshal_success(t *testing.T) {
 	if string(res) != `{"level":"PANIC"}` {
 		t.Errorf("unexpected result, %v", string(res))
 	}
+	res, _ = json.Marshal(test{Level: slf.LevelFatal})
+	if string(res) != `{"level":"FATAL"}` {
+		t.Errorf("unexpected result, %v", string(res))
+	}
 }
 
 func TestLevel_marshal_withWrongLevel_error(t *testing.T) {
@@ -70,6 +74,11 @@ func TestLevel_unmarshal_success(t *testing.T) {
 	exp = test{Level: slf.LevelPanic}
 	act = test{}
 	if err := json.Unmarshal([]byte(`{"level":"panic"}`), &act); err != nil || exp != act {
+		t.Errorf("expected match, %v, %v", err, act)
+	}
+	exp = test{Level: slf.LevelFatal}
+	act = test{}
+	if err := json.Unmarshal([]byte(`{"level":"fatal"}`), &act); err != nil || exp != act {
 		t.Errorf("expected match, %v, %v", err, act)
 	}
 }

--- a/noop.go
+++ b/noop.go
@@ -6,10 +6,11 @@ package slf
 import (
 	"errors"
 	"fmt"
+	"os"
 )
 
 // Noop implements the LogFactory, StructuredLogger and Logger interfaces with void operations
-// (except for panic in Panic and Panicf).
+// (except for panic in Panic and Panicf, and os.Exit(1) in Fatal and Fatalf).
 type Noop struct{}
 
 // WithContext implements the Logger interface.
@@ -90,6 +91,16 @@ func (*Noop) Panic(message string) {
 // Panicf implements the Logger interface.
 func (*Noop) Panicf(message string, args ...interface{}) {
 	panic(fmt.Errorf(message, args...))
+}
+
+// Fatal implements the Logger interface.
+func (*Noop) Fatal(message string) {
+	os.Exit(1)
+}
+
+// Fatalf implements the Logger interface.
+func (*Noop) Fatalf(message string, args ...interface{}) {
+	os.Exit(1)
 }
 
 // Trace implements the Logger interface.

--- a/slf.go
+++ b/slf.go
@@ -50,7 +50,6 @@ type StructuredLogger interface {
 
 // Logger represents a generic leveled log interface.
 type Logger interface {
-
 	// Log logs the string with the given level.
 	Log(Level, string) Tracer
 
@@ -83,6 +82,12 @@ type Logger interface {
 
 	// Panicf formats and logs the string with the corresponding level and panics.
 	Panicf(string, ...interface{})
+
+	// Fatal logs the string with the corresponding level and then calls os.Exit(1).
+	Fatal(string)
+
+	// Fatalf formats and logs the string with the corresponding level and then calls os.Exit(1).
+	Fatalf(string, ...interface{})
 }
 
 // Tracer represents a logger that will trace the execution time since the last log event


### PR DESCRIPTION
I disagree that Fatal should not be an available method.
The difference between Fatal and Panic is that panic calls `panic` after logging, while Fatal should call `os.Exit` after logging.
The only possibly philosophical argument would be which level, panic or fatal, would be considered "higher" or if they should be considered equivalent.

If a `Fatal(...)` method is not allowed by this interface, then I would argue that neither should `Panic(...)` be allowed.  Force the caller to call `panic` or `os.Exit` themselves in both cases, or in neither case...
